### PR TITLE
Allow multiple hostnames per namecheap domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,11 @@ For ipsync to work with namecheap, you must first [enable it within the control 
 ```
 namecheap:
   test.com:
-    hostname: www
+    hostname: [www, '@'] # Update both www and "naked" domains
     password: password
 
   example.com:
-    hostname: test
+    hostname: test # Update test.example.com
     password: 123456
 ```
 

--- a/ip_sync/test/__init__.py
+++ b/ip_sync/test/__init__.py
@@ -21,7 +21,7 @@ class TestBase(unittest.TestCase):
 
 namecheap:
   test.com:
-    hostname: www
+    hostname: [www, '@']
     password: password
 
   example.com:

--- a/ip_sync/test/test_providers.py
+++ b/ip_sync/test/test_providers.py
@@ -69,7 +69,7 @@ class TestProviders(TestBase):
         provider.update_ip(IPv4Address(six.u('127.0.0.1')), False)
 
         self.assertEqual(0, logging_mock().info.call_count)
-        self.assertEqual(2, logging_mock().error.call_count)
+        self.assertEqual(3, logging_mock().error.call_count)
 
     @patch('logging.getLogger')
     @patch('requests.get')
@@ -101,7 +101,7 @@ class TestProviders(TestBase):
         provider.update_ip(IPv4Address(six.u('127.0.0.1')), False)
 
         self.assertEqual(0, logging_mock().info.call_count)
-        self.assertEqual(2, logging_mock().error.call_count)
+        self.assertEqual(3, logging_mock().error.call_count)
 
     @patch('logging.getLogger')
     @patch('requests.get')
@@ -124,5 +124,5 @@ class TestProviders(TestBase):
 
         provider.update_ip(IPv4Address(six.u('127.0.0.1')), False)
 
-        self.assertEqual(2, logging_mock().info.call_count)
+        self.assertEqual(3, logging_mock().info.call_count)
         self.assertEqual(0, logging_mock().error.call_count)


### PR DESCRIPTION
Fixes bug #2

Files modified:

`ip_sync/providers.py`

  * Checks to see if hostname is a string. If not,
      it presumes it is a list

`README.md`
`ip_sync/test/__init__.py`

  * Updated test.com example to match rackspace
      (with both www and naked domains)

`ip_sync/test/test_providers.py`

  * Updated tests to expect 3 calls instead of 2